### PR TITLE
Make `JSONdb` type generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare class JSONdb<T = object> {
   constructor(filePath: string, options?: { asyncWrite?: boolean, syncOnWrite?: boolean });
   
-  set(key: string, value: T) : T;
+  set(key: string, value: T) : void;
   get(key: string) : T | undefined;
   has(key: string) : boolean;
   delete(key: string) : boolean | undefined;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
-declare class JSONdb {
+declare class JSONdb<T = object> {
   constructor(filePath: string, options?: { asyncWrite?: boolean, syncOnWrite?: boolean });
   
-  set(key: string, value: object) : void;
-  get(key: string) : object | undefined;
+  set(key: string, value: T) : T;
+  get(key: string) : T | undefined;
   has(key: string) : boolean;
   delete(key: string) : boolean | undefined;
   deleteAll() : this;
   sync() : void;
-  JSON(storage?: object) : object;
+  JSON(storage?: T) : T;
 }
 
 export = JSONdb;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare class JSONdb<T = object> {
   delete(key: string) : boolean | undefined;
   deleteAll() : this;
   sync() : void;
-  JSON(storage?: T) : T;
+  JSON(storage?: Record<string, T>) : Record<string, T>;
 }
 
 export = JSONdb;


### PR DESCRIPTION
This allows users to specify what type is returned from `JSONdb#get` & `JSONdb#JSON`, as well as what type should be accepted by `JSONdb#set` & `JSONdb#JSON`.

Example:
```ts
new JSONdb<string>()
    .get('key') // returns string
```