### PR TITLE
Add two advanced options: `stringify` and `parse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ See the [Options](#options) section for more details.
 
 #### Options
 
-| **Key**     | **Value type** | **Description**                                                | **Default value**                   |
-|-------------|----------------|----------------------------------------------------------------|-------------------------------------|
-| asyncWrite  | _Boolean_      | Enables the storage to be asynchronously written to disk.      | _**false**_ (synchronous behaviour) |
-| syncOnWrite | _Boolean_      | Makes the storage be written to disk after every modification. | _**true**_                          |
-| jsonSpaces  | _Number_       | The number of spaces used for indentation in the output JSON.  | _**4**_                             |
+| **Key**     | **Value type**               | **Description**                                                | **Default value**                   |
+|-------------|------------------------------|----------------------------------------------------------------|-------------------------------------|
+| asyncWrite  | _Boolean_                    | Enables the storage to be asynchronously written to disk.      | _**false**_ (synchronous behaviour) |
+| syncOnWrite | _Boolean_                    | Makes the storage be written to disk after every modification. | _**true**_                          |
+| jsonSpaces  | _Number_                     | The number of spaces used for indentation in the output JSON.  | _**4**_                             |
+| stringify   | _Function(object) => string_ | A stringifier function to process JSON data.                   | _**JSON.stringify**_                |
+| parse       | _Function(string) => object_ | A parser function to process string data.                      | _**JSON.parse**_                    |
 
 ### Set a key
 `db.set('key', 'value');`

--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ See the [Options](#options) section for more details.
 
 #### Options
 
-| **Key**     | **Value type**               | **Description**                                                | **Default value**                   |
-|-------------|------------------------------|----------------------------------------------------------------|-------------------------------------|
-| asyncWrite  | _Boolean_                    | Enables the storage to be asynchronously written to disk.      | _**false**_ (synchronous behaviour) |
-| syncOnWrite | _Boolean_                    | Makes the storage be written to disk after every modification. | _**true**_                          |
-| jsonSpaces  | _Number_                     | The number of spaces used for indentation in the output JSON.  | _**4**_                             |
-| stringify   | _Function(object) => string_ | A stringifier function to process JSON data.                   | _**JSON.stringify**_                |
-| parse       | _Function(string) => object_ | A parser function to process string data.                      | _**JSON.parse**_                    |
+All keys are optional and will default to a safe value.
+
+| **Key**     | **Value type**               | **Description**                                                   | **Default value**                   |
+|-------------|------------------------------|-------------------------------------------------------------------|-------------------------------------|
+| asyncWrite  | _Boolean_                    | Enables the storage to be asynchronously written to disk.         | _**false**_ (synchronous behaviour) |
+| syncOnWrite | _Boolean_                    | Makes the storage be written to disk after every modification.    | _**true**_                          |
+| jsonSpaces  | _Number_                     | The number of spaces used for indentation in the output JSON.     | _**4**_                             |
+| stringify   | _Function(object) => string_ | A stringifier function to serialize JS objects into JSON strings. | _**JSON.stringify**_                |
+| parse       | _Function(string) => object_ | A parser function to deserialize JSON strings into JS objects.    | _**JSON.parse**_                    |
 
 ### Set a key
 `db.set('key', 'value');`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare class JSONdb<T = object> {
-  constructor(filePath: string, options?: { asyncWrite?: boolean, syncOnWrite?: boolean });
+  constructor(filePath: string, options?: { asyncWrite?: boolean, syncOnWrite?: boolean, jsonSpaces?: boolean, stringify?: (o:T) => string, parse?: (s:string) => (T | undefined) });
   
   set(key: string, value: T) : void;
   get(key: string) : T | undefined;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ let validateJSON = function(fileContent) {
   try {
     this.options.parse(fileContent);
   } catch (e) {
-    throw new Error('Given filePath is not empty and its content is not valid JSON.');
+    console.error('Given filePath is not empty and its content is not valid JSON.');
+    throw e;
   }
   return true;
 };

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function JSONdb(filePath, options) {
     } catch (err) {
       throw err;  // TODO: Do something meaningful
     }
-    if (validateJSON(data)) this.storage = this.options.parse(data);
+    if (validateJSON.bind(this)(data)) this.storage = this.options.parse(data);
   }
 }
 


### PR DESCRIPTION
I love the ease-of-use of this module, but I also thought of adding some more options, like if you want efficiency, or want prettier JSON, or something.
I, for one, wanted to use this to optimize for `fast-json-stringify` and `fast-json-parse`.