### PR TITLE
Fix default generic type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare class JSONdb<T = object> {
+declare class JSONdb<T = any> {
   constructor(filePath: string, options?: { asyncWrite?: boolean, syncOnWrite?: boolean, jsonSpaces?: boolean, stringify?: (o:T) => string, parse?: (s:string) => (T | undefined) });
   
   set(key: string, value: T) : void;


### PR DESCRIPTION
This PR changes the default value of the generic type T to any.

The object type is incorrect as the value could be a any value not just an object.